### PR TITLE
Refactor logging for reuse by other VFS implementations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 
     include(CTest)
     enable_testing()
-    add_test(NAME pytest COMMAND env SQLITE_WEB_LOG=99 python3 -m pytest -sv ${CMAKE_CURRENT_SOURCE_DIR}/test)
+    add_test(NAME pytest COMMAND env SQLITE_VFS_LOG=99 python3 -m pytest -sv ${CMAKE_CURRENT_SOURCE_DIR}/test)
     add_test(NAME local_stress_test COMMAND local_stress_test)
 endif()

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The extension library is `build/web_vfs.so` or `build/web_vfs.dylib`.
 
 ### Configuration
 
-The VFS logs a message to standard error upon any fatally failed HTTP request, and requests that succeed after having to be retried. The latter can be suppressed by setting `&web_log=1` in the open URI, or by setting environment `SQLITE_WEB_LOG=1` in the environment. The log level can be set to 0 to suppress all standard error logging, or increased up to 5 for individual request/response logging.
+The VFS logs a message to standard error upon any fatally failed HTTP request, and requests that succeed after having to be retried. The latter can be suppressed by setting `&vfs_log=1` in the open URI, or by setting environment `SQLITE_VFS_LOG=1` in the environment. The log level can be set to 0 to suppress all standard error logging, or increased up to 5 for verbose request/response debug logging.
 
 To disable TLS certificate and hostname verification, set `&web_insecure=1` or `SQLITE_WEB_INSECURE=1`.
 

--- a/src/SQLiteVFS.h
+++ b/src/SQLiteVFS.h
@@ -31,8 +31,9 @@ namespace SQLiteVFS {
  *   1. SQLITE_VFS_LOG environment variable
  *   2. vfs_log URI parameter (for URI-opened File)
  *   3. When compiled in DEBUG mode, 5.
- *   4. Otherwise 0.
+ *   4. Otherwise 0 (but default can be overridden by implementation)
  *
+ * Recommended levels: 1=error, 2=warning, 3=notice, 4=info, 5=debug.
  */
 class Logger : public std::ostream {
   public:

--- a/src/SQLiteVFS.h
+++ b/src/SQLiteVFS.h
@@ -6,7 +6,6 @@
 
 #include <assert.h>
 #include <iostream>
-#include <libgen.h>
 #include <memory>
 #include <string.h>
 #include <string>
@@ -85,9 +84,10 @@ class Logger : public std::ostream {
     int level_;
 };
 
+#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 #define SQLITE_VFS_LOG(msg_level, msg)                                                             \
     if (log_.level() >= msg_level) {                                                               \
-        log_ << '[' << basename(__FILE__) << ":" << __LINE__ << "] " << msg << std::endl;          \
+        log_ << '[' << __FILENAME__ << ":" << __LINE__ << "] " << msg << std::endl;                \
     }
 
 /**

--- a/src/SQLiteVFS.h
+++ b/src/SQLiteVFS.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <assert.h>
+#include <iostream>
+#include <libgen.h>
 #include <memory>
 #include <string.h>
 #include <string>
@@ -17,6 +19,77 @@ Omitted so that includer can choose whether to use sqlite3.h or sqlite3ext.h
 namespace SQLiteVFS {
 
 /**
+ * VFS logging helpers:
+ *
+ * In SQLiteVFS::File and SQLiteVFS::Base implementations, the macro
+ *
+ *   SQLITE_VFS_LOG(int level, message << for << cerr)
+ *
+ * logs the message to cerr if level is at least the active level. The active level is
+ * determined as follows:
+ *
+ *   1. SQLITE_VFS_LOG environment variable
+ *   2. vfs_log URI parameter (for URI-opened File)
+ *   3. When compiled in DEBUG mode, 5.
+ *   4. Otherwise 0.
+ *
+ */
+class Logger : public std::ostream {
+  public:
+    Logger(const char *zName = nullptr, const int DEFAULT_LEVEL = 0)
+        : std::ostream(std::cerr.rdbuf()) {
+        DetectLevel(zName, DEFAULT_LEVEL);
+    }
+
+    void DetectLevel(const char *zName = nullptr, const int DEFAULT_LEVEL = 0) {
+        int log_level = DEFAULT_LEVEL;
+#ifndef NDEBUG
+        log_level = 5;
+#endif
+
+        const char *env_log = getenv("SQLITE_VFS_LOG");
+        bool env_ok = false;
+        if (env_log && *env_log) {
+            errno = 0;
+            unsigned long env_log_level = strtoul(env_log, nullptr, 10);
+            if (errno == 0 && env_log_level != ULONG_MAX) {
+                log_level = env_log_level;
+                env_ok = true;
+            }
+        }
+
+        if (!env_ok && zName) {
+            auto uri_log_level = sqlite3_uri_int64(zName, "vfs_log", -1);
+            if (uri_log_level >= 0) {
+                log_level = (unsigned long)uri_log_level;
+            }
+        }
+
+        level_ = log_level;
+    }
+
+    template <typename T> Logger &operator<<(const T &t) {
+        std::cerr << t;
+        return *this;
+    }
+
+    Logger &operator<<(std::ostream &(*manip)(std::ostream &)) {
+        std::cerr << manip;
+        return *this;
+    }
+
+    int level() const { return level_; }
+
+  private:
+    int level_;
+};
+
+#define SQLITE_VFS_LOG(msg_level, msg)                                                             \
+    if (log_.level() >= msg_level) {                                                               \
+        log_ << '[' << basename(__FILE__) << ":" << __LINE__ << "] " << msg << std::endl;          \
+    }
+
+/**
  * Abstract base class for sqlite3_file implementations. VFS xOpen() implementations can
  * instantiate a subclass implementing all of the pure methods, then call InitHandle() to fill out
  * a sqlite3_file* Handle to hand back to the caller. The instance self-deletes upon xClose().
@@ -24,6 +97,7 @@ namespace SQLiteVFS {
 class File {
   protected:
     sqlite3_io_methods methods_;
+    Logger log_;
 
     virtual int Close() {
         delete this;
@@ -59,7 +133,7 @@ class File {
         File *this_;
     };
 
-    File() {
+    File(const char *zName) : log_(zName) {
         memset(&methods_, 0, sizeof(methods_));
         methods_.iVersion = 3; // subclasses may override to 2 or 1
     }
@@ -209,7 +283,8 @@ class FileWrapper : public File {
 
   public:
     // inner will be freed after xClose()
-    FileWrapper(const std::shared_ptr<sqlite3_file> &inner) : wrapped_(inner) {}
+    FileWrapper(const char *zName, int flags, const std::shared_ptr<sqlite3_file> &inner)
+        : File(zName), wrapped_(inner) {}
     virtual ~FileWrapper() noexcept = default;
 
     void InitHandle(sqlite3_file *pFile) noexcept override {
@@ -226,6 +301,7 @@ class Base {
   protected:
     sqlite3_vfs vfs_;
     std::string name_;
+    Logger log_;
 
     // subclass may increase if it needs a large Handle for some reason
     virtual size_t szOsFile() { return sizeof(File::Handle); }
@@ -372,7 +448,7 @@ class Wrapper : public Base {
     virtual std::unique_ptr<FileWrapper>
     NewFileWrapper(const char *zName, int flags,
                    const std::shared_ptr<sqlite3_file> &wrapped_file) {
-        return std::unique_ptr<FileWrapper>(new FileWrapper(wrapped_file));
+        return std::unique_ptr<FileWrapper>(new FileWrapper(zName, flags, wrapped_file));
     }
 
     // xOpen a FileWrapper

--- a/src/dbi.h
+++ b/src/dbi.h
@@ -103,7 +103,7 @@ class dbiHelper {
     }
 
     static int Open(HTTP::CURLconn *curlconn, const std::string &dbi_url, bool web_insecure,
-                    int web_log, std::unique_ptr<dbiHelper> &dbi, std::string &error) noexcept {
+                    int log_level, std::unique_ptr<dbiHelper> &dbi, std::string &error) noexcept {
         error.clear();
 
         bool web = true;
@@ -125,7 +125,7 @@ class dbiHelper {
             if (web_insecure) {
                 open_uri += "&web_insecure=1";
             }
-            open_uri += "&web_small_KiB=1048576&web_log=" + std::to_string(web_log);
+            open_uri += "&web_small_KiB=1048576&vfs_log=" + std::to_string(log_level);
         }
 
         sqlite3 *raw_dbiconn = nullptr;

--- a/src/web_vfs.h
+++ b/src/web_vfs.h
@@ -172,7 +172,7 @@ class File : public SQLiteVFS::File {
                                    long response_code, const HTTP::headers &response_headers,
                                    const std::string &response_body, unsigned int attempt) {
                 retried = true;
-                if (log_.level() >= 2) {
+                if (log_.level() >= 3) {
                     std::string msg = curl_easy_strerror(rc);
                     if (rc == CURLE_OK) {
                         if (response_code < 200 || response_code >= 300) {
@@ -183,7 +183,7 @@ class File : public SQLiteVFS::File {
                                   " != " + std::to_string(options.min_response_body);
                         }
                     }
-                    SQLITE_WEB_LOG(2, protocol << " GET " << reqhdrs["range"] << " retrying " << msg
+                    SQLITE_WEB_LOG(3, protocol << " GET " << reqhdrs["range"] << " retrying " << msg
                                                << " (attempt " << attempt << " of "
                                                << options.max_tries << "; " << (t.micros() / 1000)
                                                << "ms elapsed)")


### PR DESCRIPTION
Introduce a `SQLITE_VFS_LOG(level,msg)` macro with the active level set by environment variable `SQLITE_VFS_LOG` or SQLite open URI parameter `vfs_log`. Change existing web logging to this new framework.