### PR TITLE
devops: use `pkgconfig` to resolve dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,17 @@ project(sqlite_web_vfs VERSION 1.0
         DESCRIPTION "SQLite3 extension for read-only HTTP(S) database access"
         LANGUAGES C CXX)
 
+# Enable pkg-config support in CMake
+find_package(PkgConfig REQUIRED)
+
+# Find SQLite and libmicrohttpd using pkg-config
+pkg_check_modules(SQLITE REQUIRED sqlite3)
+pkg_check_modules(LIBMHD REQUIRED libmicrohttpd)
+
+include_directories(${SQLITE_INCLUDE_DIRS} ${LIBMHD_INCLUDE_DIRS})
+link_directories(${SQLITE_LIBRARY_DIRS} ${LIBMHD_LIBRARY_DIRS})
+
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ARG build_type=Release
 
 RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends --no-install-suggests \
-     ca-certificates git-core build-essential cmake \
+     ca-certificates git-core build-essential cmake pkg-config \
      libcurl4-openssl-dev sqlite3 libsqlite3-dev libmicrohttpd-dev \
      python3-pytest pylint aria2
 


### PR DESCRIPTION
This way `sqlite` and `libmicrohttpd` could be effortlessly
installed on macos via Homebrew, and the compilation will just work.

NOTE: there's also a local `sqlite` installation on MacOS; to
disambiguate with it, use `PKG_CONFIG_PATH`:

```bash
export PKG_CONFIG_PATH=/opt/homebrew/Cellar/sqlite/3.44.0/lib/pkgconfig/
```
